### PR TITLE
fix: bump esbuild target to es2021 to fix DECRQM handler hang (#2)

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -26,7 +26,7 @@ const context = await esbuild.context({
 		...builtins
 	],
 	format: 'cjs',
-	target: 'es2018',
+	target: 'es2021',
 	logLevel: "warning",
 	sourcemap: prod ? false : 'inline',
 	treeShaking: true,


### PR DESCRIPTION
## Summary

Fixes #2. Any TUI that emits DECRQM (`CSI ? Pm $ p`) during init — Claude Code 2.1.116 consistently, and likely tmux/vim terminal mode — currently hangs Termy: the screen freezes and keystrokes stop being forwarded to the PTY. Obsidian DevTools shows:

```
Uncaught ReferenceError: s is not defined
  at Iv.requestMode (plugin:termy:47:…)
  at Fv.parse (plugin:termy:47:…)
  at qv._innerWrite (plugin:termy:47:…)
```

## Root cause

xterm.js v6's `requestMode` implementation is:

```js
requestMode(e, i) {
  let r;
  (P => (P[P.NOT_RECOGNIZED = 0] = "NOT_RECOGNIZED", /* ... */))(r ||= {});
  // ...
}
```

With `target: 'es2018'`, esbuild down-levels `r ||= {}` and, while minifying, drops `let r;` (it looks unused — `r` is only assigned, never read after the IIFE) and rewrites the surviving read as `void 0`. The bundled output becomes:

```js
requestMode(e, t) {
  ((d) => (/* ... */))(void 0 || (s = {}));
  // ...
}
```

`s` is never declared in scope. The first DECRQM escape any TUI sends during init throws `ReferenceError: s is not defined`, the xterm parser's inner write loop dies, the terminal looks frozen.

## Fix

Bump esbuild `target` from `es2018` to `es2021`. `||=` is emitted natively, the backing `let s` declaration survives minification, and the IIFE becomes a well-formed `(s ||= {})` at runtime.

Obsidian desktop ships Electron with a Chromium well past ES2021, so there's no compatibility cost. Termy is already `isDesktopOnly: true` (see `manifest.json`).

## Verification

Before:

```
$ grep -c '(s={})' main.js
2
$ python3 -c "import re,sys; s=open('main.js').read(); i=s.find('requestMode(e,t)'); print(s[i:i+200])"
requestMode(e,t){(d=>(…))(void 0||(s={}));…
```

After:

```
$ grep -c '(s={})' main.js
1   # remaining occurrence is an unrelated default parameter `init(s={})`
$ python3 -c "import re,sys; s=open('main.js').read(); i=s.find('requestMode(e,t)'); print(s[i:i+200])"
requestMode(e,t){let s;(d=>(…))(s||={});…
```

Installed the rebuilt `main.js` into a real Obsidian vault and confirmed `claude` (Claude Code 2.1.116) now launches, renders the trust prompt, and accepts keystrokes end-to-end.

## Test plan

- [x] Build completes with no type errors (`pnpm build`)
- [x] `requestMode` in bundled output has `let s;` declaration
- [x] `claude` 2.1.116 TUI works in Termy 1.2.3 on macOS (reporter of issue #2 saw the same failure on Windows 11)